### PR TITLE
AF-593+: Move XStreamUtils to kie-soup.

### DIFF
--- a/kie-soup-commons/pom.xml
+++ b/kie-soup-commons/pom.xml
@@ -43,6 +43,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -67,6 +72,7 @@
               org.kie.soup.commons.*
             </Export-Package>
             <Import-Package>
+              com.thoughtworks.xstream.*;resolution:=optional,
               *
             </Import-Package>
             <_removeheaders>Private-Package</_removeheaders>

--- a/kie-soup-commons/src/main/java/org/kie/soup/commons/xstream/AnyAnnotationTypePermission.java
+++ b/kie-soup-commons/src/main/java/org/kie/soup/commons/xstream/AnyAnnotationTypePermission.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.soup.commons.xstream;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAliasType;
+import com.thoughtworks.xstream.annotations.XStreamInclude;
+import com.thoughtworks.xstream.security.TypePermission;
+
+/**
+ * Permission for any type which is annotated with an XStream annotation.
+ * This presumes that because the class has an XStream annotation, it was designed with XStream in mind,
+ * and therefore it is not vulnerable. Jackson and JAXB follow this philosophy too.
+ */
+// TODO Replace with upstream one when upgrading to XStream 1.5.0
+// See https://github.com/x-stream/xstream/pull/99)
+public class AnyAnnotationTypePermission implements TypePermission {
+
+    @Override
+    public boolean allows(final Class type) {
+        if (type == null) {
+            return false;
+        }
+        return type.isAnnotationPresent(XStreamAlias.class)
+                || type.isAnnotationPresent(XStreamAliasType.class)
+                || type.isAnnotationPresent(XStreamInclude.class);
+    }
+
+}

--- a/kie-soup-commons/src/main/java/org/kie/soup/commons/xstream/LocalDateTimeXStreamConverter.java
+++ b/kie-soup-commons/src/main/java/org/kie/soup/commons/xstream/LocalDateTimeXStreamConverter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.soup.commons.xstream;
+
+import java.time.DateTimeException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * TODO Remove when java.time converters are provided by XStream out of the box.
+ *
+ * @see <a href="https://github.com/x-stream/xstream/issues/75">XStream#75</a>
+ */
+public class LocalDateTimeXStreamConverter implements Converter {
+
+    private final DateTimeFormatter formatter;
+
+    public LocalDateTimeXStreamConverter() {
+        formatter = new DateTimeFormatterBuilder()
+                .appendPattern( "uuuu-MM-dd'T'HH:mm:ss" )
+                .appendFraction( ChronoField.NANO_OF_SECOND, 0, 9, true )
+                .toFormatter();
+    }
+
+    @Override
+    public void marshal( Object localDateTimeObject, HierarchicalStreamWriter writer, MarshallingContext context ) {
+        LocalDateTime localDateTime = (LocalDateTime) localDateTimeObject;
+        writer.setValue( formatter.format( localDateTime ) );
+    }
+
+    @Override
+    public Object unmarshal( HierarchicalStreamReader reader, UnmarshallingContext context ) {
+        String localDateTimeString = reader.getValue();
+        try {
+            return LocalDateTime.from( formatter.parse( localDateTimeString ) );
+        } catch ( DateTimeException e ) {
+            throw new IllegalStateException( "Failed to convert string (" + localDateTimeString + ") to type ("
+                    + LocalDateTime.class.getName() + ")." );
+        }
+    }
+
+    @Override
+    public boolean canConvert( Class type ) {
+        return LocalDateTime.class.isAssignableFrom( type );
+    }
+
+}

--- a/kie-soup-commons/src/main/java/org/kie/soup/commons/xstream/LocalDateXStreamConverter.java
+++ b/kie-soup-commons/src/main/java/org/kie/soup/commons/xstream/LocalDateXStreamConverter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.soup.commons.xstream;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * TODO Remove when java.time converters are provided by XStream out of the box.
+ *
+ * @see <a href="https://github.com/x-stream/xstream/issues/75">XStream#75</a>
+ */
+public class LocalDateXStreamConverter implements Converter {
+
+    @Override
+    public void marshal( Object localDateObject, HierarchicalStreamWriter writer, MarshallingContext context ) {
+        LocalDate localDate = (LocalDate) localDateObject;
+        writer.setValue( localDate.toString() );
+    }
+
+    @Override
+    public Object unmarshal( HierarchicalStreamReader reader, UnmarshallingContext context ) {
+        String localDateString = reader.getValue();
+        try {
+            return LocalDate.parse( localDateString );
+        } catch ( DateTimeException e ) {
+            throw new IllegalStateException( "Failed to convert string (" + localDateString + ") to type ("
+                    + LocalDate.class.getName() + ")." );
+        }
+    }
+
+    @Override
+    public boolean canConvert( Class type ) {
+        return LocalDate.class.isAssignableFrom( type );
+    }
+
+}

--- a/kie-soup-commons/src/main/java/org/kie/soup/commons/xstream/LocalTimeXStreamConverter.java
+++ b/kie-soup-commons/src/main/java/org/kie/soup/commons/xstream/LocalTimeXStreamConverter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.soup.commons.xstream;
+
+import java.time.DateTimeException;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * TODO Remove when java.time converters are provided by XStream out of the box.
+ *
+ * @see <a href="https://github.com/x-stream/xstream/issues/75">XStream#75</a>
+ */
+public class LocalTimeXStreamConverter implements Converter {
+
+    private final DateTimeFormatter formatter;
+
+    public LocalTimeXStreamConverter() {
+        formatter = new DateTimeFormatterBuilder()
+                .appendPattern( "HH:mm:ss" )
+                .appendFraction( ChronoField.NANO_OF_SECOND, 0, 9, true )
+                .toFormatter();
+    }
+
+    @Override
+    public void marshal( Object localTimeObject, HierarchicalStreamWriter writer, MarshallingContext context ) {
+        LocalTime localTime = (LocalTime) localTimeObject;
+        writer.setValue( formatter.format( localTime ) );
+    }
+
+    @Override
+    public Object unmarshal( HierarchicalStreamReader reader, UnmarshallingContext context ) {
+        String localTimeString = reader.getValue();
+        try {
+            return LocalTime.from( formatter.parse( localTimeString ) );
+        } catch ( DateTimeException e ) {
+            throw new IllegalStateException( "Failed to convert string (" + localTimeString + ") to type ("
+                    + LocalTime.class.getName() + ")." );
+        }
+    }
+
+    @Override
+    public boolean canConvert( Class type ) {
+        return LocalTime.class.isAssignableFrom( type );
+    }
+
+}

--- a/kie-soup-commons/src/main/java/org/kie/soup/commons/xstream/OffsetDateTimeXStreamConverter.java
+++ b/kie-soup-commons/src/main/java/org/kie/soup/commons/xstream/OffsetDateTimeXStreamConverter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.soup.commons.xstream;
+
+import java.time.DateTimeException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.MarshallingContext;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+/**
+ * TODO Remove when java.time converters are provided by XStream out of the box.
+ *
+ * @see <a href="https://github.com/x-stream/xstream/issues/75">XStream#75</a>
+ */
+public class OffsetDateTimeXStreamConverter implements Converter {
+
+    private final DateTimeFormatter formatter;
+
+    public OffsetDateTimeXStreamConverter() {
+        formatter = new DateTimeFormatterBuilder()
+                .appendPattern( "uuuu-MM-dd'T'HH:mm:ss" )
+                .appendFraction( ChronoField.NANO_OF_SECOND, 0, 9, true )
+                .appendOffsetId()
+                .toFormatter();
+    }
+
+    @Override
+    public void marshal( Object localTimeObject, HierarchicalStreamWriter writer, MarshallingContext context ) {
+        OffsetDateTime offsetDateTime = (OffsetDateTime) localTimeObject;
+        writer.setValue( formatter.format( offsetDateTime ) );
+    }
+
+    @Override
+    public Object unmarshal( HierarchicalStreamReader reader, UnmarshallingContext context ) {
+        String offsetDateTimeString = reader.getValue();
+        try {
+            return OffsetDateTime.from( formatter.parse( offsetDateTimeString ) );
+        } catch ( DateTimeException e ) {
+            throw new IllegalStateException( "Failed to convert string (" + offsetDateTimeString + ") to type ("
+                    + OffsetDateTime.class.getName() + ")." );
+        }
+    }
+
+    @Override
+    public boolean canConvert( Class type ) {
+        return OffsetDateTime.class.isAssignableFrom( type );
+    }
+
+}

--- a/kie-soup-commons/src/main/java/org/kie/soup/commons/xstream/XStreamUtils.java
+++ b/kie-soup-commons/src/main/java/org/kie/soup/commons/xstream/XStreamUtils.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.soup.commons.xstream;
+
+import java.util.function.Function;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.converters.reflection.ReflectionProvider;
+import com.thoughtworks.xstream.core.ClassLoaderReference;
+import com.thoughtworks.xstream.io.HierarchicalStreamDriver;
+import com.thoughtworks.xstream.mapper.MapperWrapper;
+import com.thoughtworks.xstream.security.AnyTypePermission;
+import com.thoughtworks.xstream.security.WildcardTypePermission;
+
+import static com.thoughtworks.xstream.XStream.setupDefaultSecurity;
+
+public class XStreamUtils {
+
+    private static final String[] WHITELISTED_PACKAGES = new String[] {
+        "org.drools.core.command.**",
+        "org.drools.core.runtime.impl.ExecutionResultImpl",
+        "org.drools.core.runtime.rule.impl.FlatQueryResults",
+        "org.drools.core.common.DefaultFactHandle",
+        "org.drools.core.common.EventFactHandle"
+    };
+
+    /**
+     * Vulnerable to CVE-210137285 variants. Do not use. Will be removed in the next few days!
+     * @deprecated in favor of {@link #createTrustingXStream()} and {@link #createNonTrustingXStream()}
+     */
+    @Deprecated
+    public static XStream createXStream() {
+        return internalCreateXStream( new XStream() );
+    }
+
+    /**
+     * Vulnerable to CVE-210137285 variants. Do not use. Will be removed in the next few days!
+     * @deprecated in favor of {@link #createTrustingXStream()} and {@link #createNonTrustingXStream()}
+     */
+    @Deprecated
+    public static XStream createXStream(HierarchicalStreamDriver hierarchicalStreamDriver) {
+        return internalCreateXStream( new XStream(hierarchicalStreamDriver) );
+    }
+
+    /**
+     * Vulnerable to CVE-210137285 variants. Do not use. Will be removed in the next few days!
+     * @deprecated in favor of {@link #createTrustingXStream()} and {@link #createNonTrustingXStream()}
+     */
+    @Deprecated
+    public static XStream createXStream(HierarchicalStreamDriver hierarchicalStreamDriver, ClassLoader classLoader) {
+        return internalCreateXStream( new XStream(null, hierarchicalStreamDriver, new ClassLoaderReference( classLoader )) );
+    }
+
+    /**
+     * Vulnerable to CVE-210137285 variants. Do not use. Will be removed in the next few days!
+     * @deprecated in favor of {@link #createTrustingXStream()} and {@link #createNonTrustingXStream()}
+     */
+    @Deprecated
+    public static XStream createXStream(ReflectionProvider reflectionProvider ) {
+        return internalCreateXStream( new XStream(reflectionProvider) );
+    }
+
+    /**
+     * Vulnerable to CVE-210137285 variants. Do not use. Will be removed in the next few days!
+     * @deprecated in favor of {@link #createTrustingXStream()} and {@link #createNonTrustingXStream()}
+     */
+    @Deprecated
+    public static XStream createXStream(ReflectionProvider reflectionProvider, Function<MapperWrapper, MapperWrapper> mapper ) {
+        return internalCreateXStream( new XStream(reflectionProvider) {
+            protected MapperWrapper wrapMapper(MapperWrapper next) {
+                return mapper.apply( next );
+            }
+        });
+    }
+
+    /**
+     * Vulnerable to CVE-210137285 variants. Do not use. Will be removed in the next few days!
+     * @deprecated in favor of {@link #createTrustingXStream()} and {@link #createNonTrustingXStream()}
+     */
+    @Deprecated
+    private static XStream internalCreateXStream( XStream xstream ) {
+        setupDefaultSecurity(xstream);
+        xstream.addPermission( new WildcardTypePermission( new String[] {
+                "java.**", "javax.**", "org.kie.**", "org.drools.**", "org.jbpm.**", "org.optaplanner.**", "org.appformer.**"
+        } ) );
+        return xstream;
+    }
+
+    /**
+     * Only use for XML or JSON that comes from a 100% trusted source.
+     * The XML/JSON must be as safe as executable java code.
+     * Otherwise, you MUST use {@link #createNonTrustingXStream()}.
+     */
+    public static XStream createTrustingXStream() {
+        return internalCreateTrustingXStream( new XStream() );
+    }
+
+    /**
+     * Only use for XML or JSON that comes from a 100% trusted source.
+     * The XML/JSON must be as safe as executable java code.
+     * Otherwise, you MUST use {@link #createNonTrustingXStream()}.
+     */
+    public static XStream createTrustingXStream(HierarchicalStreamDriver hierarchicalStreamDriver) {
+        return internalCreateTrustingXStream( new XStream(hierarchicalStreamDriver) );
+    }
+
+    /**
+     * Only use for XML or JSON that comes from a 100% trusted source.
+     * The XML/JSON must be as safe as executable java code.
+     * Otherwise, you MUST use {@link #createNonTrustingXStream()}.
+     */
+    public static XStream createTrustingXStream(HierarchicalStreamDriver hierarchicalStreamDriver, ClassLoader classLoader) {
+        return internalCreateTrustingXStream( new XStream(null, hierarchicalStreamDriver, new ClassLoaderReference( classLoader )) );
+    }
+
+    /**
+     * Only use for XML or JSON that comes from a 100% trusted source.
+     * The XML/JSON must be as safe as executable java code.
+     * Otherwise, you MUST use {@link #createNonTrustingXStream()}.
+     */
+    public static XStream createTrustingXStream(ReflectionProvider reflectionProvider ) {
+        return internalCreateTrustingXStream( new XStream(reflectionProvider) );
+    }
+    
+    /**
+     * Only use for XML or JSON that comes from a 100% trusted source.
+     * The XML/JSON must be as safe as executable java code.
+     * Otherwise, you MUST use {@link #createNonTrustingXStream()}.
+     */
+    public static XStream createTrustingXStream(ReflectionProvider reflectionProvider, HierarchicalStreamDriver hierarchicalStreamDriver ) {
+        return internalCreateTrustingXStream( new XStream(reflectionProvider, hierarchicalStreamDriver) );
+    }
+
+    /**
+     * Only use for XML or JSON that comes from a 100% trusted source.
+     * The XML/JSON must be as safe as executable java code.
+     * Otherwise, you MUST use {@link #createNonTrustingXStream()}.
+     */
+    public static XStream createTrustingXStream(ReflectionProvider reflectionProvider, Function<MapperWrapper, MapperWrapper> mapper ) {
+        return internalCreateTrustingXStream( new XStream(reflectionProvider) {
+            protected MapperWrapper wrapMapper(MapperWrapper next) {
+                return mapper.apply( next );
+            }
+        });
+    }
+
+    /**
+     * Only use for XML or JSON that comes from a 100% trusted source.
+     * The XML/JSON must be as safe as executable java code.
+     * Otherwise, you MUST use {@link #createNonTrustingXStream()}.
+     */
+    private static XStream internalCreateTrustingXStream( XStream xstream ) {
+        setupDefaultSecurity(xstream);
+        // Presumes the XML content comes from a trusted source!
+        xstream.addPermission(new AnyTypePermission());
+        return xstream;
+    }
+
+    /**
+     * Use for XML or JSON that might not come from a trusted source (such as REST services payloads, ...).
+     * Automatically whitelists all classes with an {@link XStreamAlias} annotation.
+     * Often requires whitelisting additional domain specific classes, which you'll need to expose in your API's.
+     */
+    public static XStream createNonTrustingXStream() {
+        return internalCreateNonTrustingXStream( new XStream() );
+    }
+
+    /**
+     * Use for XML or JSON that might not come from a trusted source (such as REST services payloads, ...).
+     * Automatically whitelists all classes with an {@link XStreamAlias} annotation.
+     * Often requires whitelisting additional domain specific classes, which you'll need to expose in your API's.
+     */
+    public static XStream createNonTrustingXStream(HierarchicalStreamDriver hierarchicalStreamDriver) {
+        return internalCreateNonTrustingXStream( new XStream(hierarchicalStreamDriver) );
+    }
+
+    /**
+     * Use for XML or JSON that might not come from a trusted source (such as REST services payloads, ...).
+     * Automatically whitelists all classes with an {@link XStreamAlias} annotation.
+     * Often requires whitelisting additional domain specific classes, which you'll need to expose in your API's.
+     */
+    public static XStream createNonTrustingXStream(HierarchicalStreamDriver hierarchicalStreamDriver, ClassLoader classLoader) {
+        return internalCreateNonTrustingXStream( new XStream(null, hierarchicalStreamDriver, new ClassLoaderReference( classLoader )) );
+    }
+
+    /**
+     * Use for XML or JSON that might not come from a trusted source (such as REST services payloads, ...).
+     * Automatically whitelists all classes with an {@link XStreamAlias} annotation.
+     * Often requires whitelisting additional domain specific classes, which you'll need to expose in your API's.
+     */
+    public static XStream createNonTrustingXStream(ReflectionProvider reflectionProvider ) {
+        return internalCreateNonTrustingXStream( new XStream(reflectionProvider) );
+    }
+    
+    /**
+     * Use for XML or JSON that might not come from a trusted source (such as REST services payloads, ...).
+     * Automatically whitelists all classes with an {@link XStreamAlias} annotation.
+     * Often requires whitelisting additional domain specific classes, which you'll need to expose in your API's.
+     */
+    public static XStream createNonTrustingXStream(ReflectionProvider reflectionProvider, HierarchicalStreamDriver hierarchicalStreamDriver ) {
+        return internalCreateNonTrustingXStream( new XStream(reflectionProvider, hierarchicalStreamDriver) );
+    }
+
+    /**
+     * Use for XML or JSON that might not come from a trusted source (such as REST services payloads, ...).
+     * Automatically whitelists all classes with an {@link XStreamAlias} annotation.
+     * Often requires whitelisting additional domain specific classes, which you'll need to expose in your API's.
+     */
+    public static XStream createNonTrustingXStream(ReflectionProvider reflectionProvider, Function<MapperWrapper, MapperWrapper> mapper ) {
+        return internalCreateNonTrustingXStream( new XStream(reflectionProvider) {
+            protected MapperWrapper wrapMapper(MapperWrapper next) {
+                return mapper.apply( next );
+            }
+        });
+    }
+
+    /**
+     * Use for XML or JSON that might not come from a trusted source (such as REST services payloads, ...).
+     * Automatically whitelists all classes with an {@link XStreamAlias} annotation.
+     * Often requires whitelisting additional domain specific classes, which you'll need to expose in your API's.
+     */
+    private static XStream internalCreateNonTrustingXStream( XStream xstream ) {
+        setupDefaultSecurity(xstream);
+        // TODO remove if setupDefaultSecurity already does this.
+        // See comment in https://github.com/x-stream/xstream/pull/99
+        xstream.addPermission( new AnyAnnotationTypePermission());
+        xstream.addPermission( new WildcardTypePermission( WHITELISTED_PACKAGES ) );
+        // Do not add root permissions for "java", "org.kie" or the like here because that creates a security problem.
+        // For more information, see http://x-stream.github.io/security.html and various xstream dev list conversations.
+        // Instead, embrace a whitelist approach and expose that in your API's.
+        return xstream;
+    }
+
+}


### PR DESCRIPTION
This PR fixes a bad dependency from uberfire onto kie-internal (since droolsjbpm-knowledge is built after uberfire in the build system). This dependency was a temporary side-effect of migrating Guvnor modules to uberfire.