### PR TITLE
RHDM-24: updated jackson version to be the same as in kie-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   <properties>
     <!-- Required since support for ELS 2.x. Keep in sync with kie-parent or remove when those
           two versions are being updated on the IP BOM.-->
-    <version.com.fasterxml.jackson>2.6.2</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.8.9</version.com.fasterxml.jackson>
     <version.com.googlecode.jsonsimple>1.1.1</version.com.googlecode.jsonsimple>
     <version.org.mvel>2.3.2.Final</version.org.mvel>
     <version.org.elasticsearch>5.6.1</version.org.elasticsearch>


### PR DESCRIPTION
https://issues.jboss.org/browse/RHDM-24