### PR TITLE
[7.5.x] DROOLS-2263: Cover case when not all enums use quote character

### DIFF
--- a/kie-soup-commons/src/main/java/org/kie/soup/commons/util/ListSplitter.java
+++ b/kie-soup-commons/src/main/java/org/kie/soup/commons/util/ListSplitter.java
@@ -63,7 +63,7 @@ class InnerSplitter {
                     } else {
                         result.add(item.substring(item.indexOf(this.quoteCharacter) + 1, item.lastIndexOf(this.quoteCharacter)));
                     }
-                } else if (item.startsWith(this.quoteCharacter)) {
+                } else if (item.trim().startsWith(this.quoteCharacter)) {
                     current = item.substring(item.indexOf(this.quoteCharacter) + 1) + ",";
                 } else {
                     if (trim) {

--- a/kie-soup-commons/src/test/java/org/kie/soup/commons/util/ListSplitterTest.java
+++ b/kie-soup-commons/src/test/java/org/kie/soup/commons/util/ListSplitterTest.java
@@ -94,4 +94,37 @@ public class ListSplitterTest {
         assertEquals("Helsinki, Finland", split[0]);
         assertEquals(" Boston", split[1]);
     }
+
+    @Test
+    public void testQuoteCharacterUsedJustForComplexEnumEnd() throws Exception {
+        final String[] split = ListSplitter.split("\"",
+                                                  true,
+                                                  "Prague, Boston, \"Helsinki, Finland\"");
+        assertEquals(3, split.length);
+        assertEquals("Prague", split[0]);
+        assertEquals("Boston", split[1]);
+        assertEquals("Helsinki, Finland", split[2]);
+    }
+
+    @Test
+    public void testQuoteCharacterUsedJustForComplexEnumMiddle() throws Exception {
+        final String[] split = ListSplitter.split("\"",
+                                                  true,
+                                                  "Prague, \"Helsinki, Finland\", Boston");
+        assertEquals(3, split.length);
+        assertEquals("Prague", split[0]);
+        assertEquals("Helsinki, Finland", split[1]);
+        assertEquals("Boston", split[2]);
+    }
+
+    @Test
+    public void testQuoteCharacterUsedJustForComplexEnumStart() throws Exception {
+        final String[] split = ListSplitter.split("\"",
+                                                  true,
+                                                  "\"Helsinki, Finland\", Prague, Boston");
+        assertEquals(3, split.length);
+        assertEquals("Helsinki, Finland", split[0]);
+        assertEquals("Prague", split[1]);
+        assertEquals("Boston", split[2]);
+    }
 }


### PR DESCRIPTION
This is **cherry-pick** of #31 
@manstis @Rikkola please have a look.