### PR TITLE
AF-1145 test fix as cherry pick

### DIFF
--- a/kie-soup-dataset/kie-soup-dataset-elasticsearch/src/test/resources/elasticsearch.yml
+++ b/kie-soup-dataset/kie-soup-dataset-elasticsearch/src/test/resources/elasticsearch.yml
@@ -1,6 +1,0 @@
-cluster.name: elasticsearch
-transport.host: 0.0.0.0
-http.host: 0.0.0.0
-transport.tcp.port: 9300
-xpack.security.enabled: false
-discovery.zen.minimum_master_nodes: 1


### PR DESCRIPTION
ElasticSearchTests failing if container already exists
https://issues.jboss.org/browse/AF-1145
