### PR TITLE
[7.7.x] DROOLS-2629 : Complex enumerations are not selected in BRL multi value constraint (#47)

### DIFF
--- a/kie-soup-commons/src/main/java/org/kie/soup/commons/util/ListSplitter.java
+++ b/kie-soup-commons/src/main/java/org/kie/soup/commons/util/ListSplitter.java
@@ -39,6 +39,23 @@ public class ListSplitter {
                                  trim,
                                  split).getSplit();
     }
+
+    public static String[] splitPreserveQuotes(final String quoteCharacter,
+                                               final boolean trim,
+                                               final String valueList) {
+        final String[] split = valueList.split(",");
+        final String[] result = new InnerSplitter(quoteCharacter,
+                                                  trim,
+                                                  split).getSplit();
+
+        for (int i = 0; i < result.length; i++) {
+            if (result[i].contains(",")) {
+                result[i] = quoteCharacter + result[i] + quoteCharacter;
+            }
+        }
+
+        return result;
+    }
 }
 
 class InnerSplitter {
@@ -74,8 +91,8 @@ class InnerSplitter {
                 }
             } else {
 
-                if (item.endsWith(this.quoteCharacter)) {
-                    current += item.substring(0, item.length() - 1);
+                if (item.trim().endsWith(this.quoteCharacter)) {
+                    current += item.substring(0, item.lastIndexOf(this.quoteCharacter) );
                     result.add(current);
                     current = null;
                 } else {

--- a/kie-soup-commons/src/test/java/org/kie/soup/commons/util/ListSplitterTest.java
+++ b/kie-soup-commons/src/test/java/org/kie/soup/commons/util/ListSplitterTest.java
@@ -16,7 +16,7 @@ package org.kie.soup.commons.util;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class ListSplitterTest {
 
@@ -86,6 +86,16 @@ public class ListSplitterTest {
     }
 
     @Test
+    public void changeQuoteCharacterPreserveQuotes() throws Exception {
+        final String[] split = ListSplitter.splitPreserveQuotes("\"",
+                                                                true,
+                                                                "\"Helsinki, Finland\", Boston");
+        assertEquals(2, split.length);
+        assertEquals("\"Helsinki, Finland\"", split[0]);
+        assertEquals("Boston", split[1]);
+    }
+
+    @Test
     public void changeQuoteCharacterSkipTrimming() throws Exception {
         final String[] split = ListSplitter.split("\"",
                                                   false,
@@ -115,6 +125,16 @@ public class ListSplitterTest {
         assertEquals("Prague", split[0]);
         assertEquals("Helsinki, Finland", split[1]);
         assertEquals("Boston", split[2]);
+    }
+
+    @Test
+    public void testDoubleQuotes() throws Exception {
+        final String[] split = ListSplitter.split("\"",
+                                                  true,
+                                                  " \"Prague\", \"\"Helsinki, Finland\"\" ");
+        assertEquals(2, split.length);
+        assertEquals("Prague", split[0]);
+        assertEquals("\"Helsinki, Finland\"", split[1]);
     }
 
     @Test


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-2629

(cherry picked from commit e2db1470676940ee99da79d35d932cde17371f93)

Fix is in two PRs:
https://github.com/kiegroup/kie-soup/pull/49
https://github.com/kiegroup/kie-wb-common/pull/1913