### PR TITLE
upgraded jboss-ip-bom to 8.1.0.Final

### DIFF
--- a/kie-soup-bom/pom.xml
+++ b/kie-soup-bom/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
     <!-- Keep in sync with the parent version of ../pom.xml -->
-    <version>8.1.0.CR2</version>
+    <version>8.1.0.Final</version>
     <relativePath/>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-bom</artifactId>
     <!-- Keep in sync with the parent version of kie-soup-bom/pom.xml -->
-    <version>8.1.0.CR2</version>
+    <version>8.1.0.Final</version>
   </parent>
 
   <groupId>org.kie.soup</groupId>


### PR DESCRIPTION
jboss-ip-bom 8.1.0.Final is identical to 8.1.0.CR2 - we had to do this as prod will work only with Final versions. In future there won't be anymore CRs for jboss-ip-bom - only Final versions.