### PR TITLE
Use <target> instead of deprecated <tasks> in antrun plugin config

### DIFF
--- a/kie-soup-maven-utils/kie-soup-maven-integration/pom.xml
+++ b/kie-soup-maven-utils/kie-soup-maven-integration/pom.xml
@@ -182,9 +182,9 @@
             <id>create-custom-maven-repo-dir</id>
             <phase>generate-test-resources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <mkdir dir="${project.build.directory}/testing-maven-repo"/>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>


### PR DESCRIPTION
Fixes the warning
"[WARNING] Parameter tasks is deprecated, use target instead"

See maven-antrun-plugin [docs](http://maven.apache.org/plugins/maven-antrun-plugin/run-mojo.html#tasks)