### PR TITLE
AF-1670 Fix reading scope dependency attribute in MinimalPomParser

### DIFF
--- a/kie-soup-maven-utils/kie-soup-maven-support/src/main/java/org/appformer/maven/support/MinimalPomParser.java
+++ b/kie-soup-maven-utils/kie-soup-maven-support/src/main/java/org/appformer/maven/support/MinimalPomParser.java
@@ -71,7 +71,7 @@ public class MinimalPomParser extends DefaultHandler {
                              final String localName,
                              final String qname,
                              final Attributes attrs) throws SAXException {
-        if ( "groupId".equals( qname ) || "artifactId".equals( qname ) || "version".equals( qname ) ) {
+        if ( "groupId".equals( qname ) || "artifactId".equals( qname ) || "version".equals( qname ) || "scope".equals( qname ) ) {
             this.characters = new StringBuilder();            
         }
         

--- a/kie-soup-maven-utils/kie-soup-maven-support/src/test/java/org/appformer/maven/support/MinimalPomParserTest.java
+++ b/kie-soup-maven-utils/kie-soup-maven-support/src/test/java/org/appformer/maven/support/MinimalPomParserTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.maven.support;
+
+import java.io.InputStream;
+import java.util.Collection;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class MinimalPomParserTest {
+
+    @Test
+    public void testMinimalPomParser() {
+        final InputStream is = MinimalPomParserTest.class.getResourceAsStream("pom.xml");
+        assertNotNull(is);
+
+        final PomModel model = MinimalPomParser.parse(MinimalPomParserTest.class.getName().replace( '.', '/' ) + ".pom.xml", is);
+        ParserTestUtil.assertPomModel(model);
+
+        Collection<AFReleaseId> dependencies = model.getDependencies(DependencyFilter.TAKE_ALL_FILTER);
+        assertNotNull(dependencies);
+        assertEquals(1, dependencies.size());
+
+        dependencies = model.getDependencies(DependencyFilter.COMPILE_FILTER);
+        assertNotNull(dependencies);
+        assertEquals(0, dependencies.size());
+    }
+}

--- a/kie-soup-maven-utils/kie-soup-maven-support/src/test/java/org/appformer/maven/support/ParserTestUtil.java
+++ b/kie-soup-maven-utils/kie-soup-maven-support/src/test/java/org/appformer/maven/support/ParserTestUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.maven.support;
+
+import static org.junit.Assert.assertEquals;
+
+public final class ParserTestUtil {
+
+    public static void assertPomModel(final PomModel pomModel) {
+        assertEquals( "groupId", pomModel.getReleaseId().getGroupId() );
+        assertEquals( "artifactId", pomModel.getReleaseId().getArtifactId() );
+        assertEquals( "version", pomModel.getReleaseId().getVersion() );
+
+        assertEquals( "parentGroupId", pomModel.getParentReleaseId().getGroupId() );
+        assertEquals( "parentArtifactId", pomModel.getParentReleaseId().getArtifactId() );
+        assertEquals( "parentVersion", pomModel.getParentReleaseId().getVersion() );
+
+        assertEquals( 1, pomModel.getDependencies().size() );
+        AFReleaseId dep = pomModel.getDependencies().iterator().next();
+        assertEquals( "dep1GroupId", dep.getGroupId() );
+        assertEquals( "dep1ArtifactId", dep.getArtifactId() );
+        assertEquals( "dep1Version", dep.getVersion() );
+    }
+
+    public ParserTestUtil() {
+        // It is forbidden to instantiate util classes.
+    }
+}

--- a/kie-soup-maven-utils/kie-soup-maven-support/src/test/java/org/appformer/maven/support/PomModelParserTest.java
+++ b/kie-soup-maven-utils/kie-soup-maven-support/src/test/java/org/appformer/maven/support/PomModelParserTest.java
@@ -19,7 +19,6 @@ import java.io.InputStream;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class PomModelParserTest {
@@ -30,18 +29,6 @@ public class PomModelParserTest {
         assertNotNull( is );
         
         PomModel pomModel = PomModel.Parser.parse( PomModelParserTest.class.getName().replace( '.', '/' ) + ".pom.xml", is );
-        assertEquals( "groupId", pomModel.getReleaseId().getGroupId() );
-        assertEquals( "artifactId", pomModel.getReleaseId().getArtifactId() );
-        assertEquals( "version", pomModel.getReleaseId().getVersion() );
-        
-        assertEquals( "parentGroupId", pomModel.getParentReleaseId().getGroupId() );
-        assertEquals( "parentArtifactId", pomModel.getParentReleaseId().getArtifactId() );
-        assertEquals( "parentVersion", pomModel.getParentReleaseId().getVersion() );
-
-        assertEquals( 1, pomModel.getDependencies().size() );
-        AFReleaseId dep = pomModel.getDependencies().iterator().next();
-        assertEquals( "dep1GroupId", dep.getGroupId() );
-        assertEquals( "dep1ArtifactId", dep.getArtifactId() );
-        assertEquals( "dep1Version", dep.getVersion() );
+        ParserTestUtil.assertPomModel(pomModel);
     }
 }

--- a/kie-soup-maven-utils/kie-soup-maven-support/src/test/resources/org/appformer/maven/support/pom.xml
+++ b/kie-soup-maven-utils/kie-soup-maven-support/src/test/resources/org/appformer/maven/support/pom.xml
@@ -19,7 +19,8 @@
     <dependency>
       <groupId>dep1GroupId</groupId>
       <artifactId>dep1ArtifactId</artifactId>
-     <version>dep1Version</version>
+      <version>dep1Version</version>
+      <scope>provided</scope>
     </dependency>     
   </dependencies>
   


### PR DESCRIPTION
@domhanak @ederign @desmax74 please review. There was missing start tag handling for <scope>. 