### PR TITLE
addAll method implemented for lists builder

### DIFF
--- a/kie-soup-commons/pom.xml
+++ b/kie-soup-commons/pom.xml
@@ -56,6 +56,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/kie-soup-commons/src/main/java/org/kie/soup/commons/util/Lists.java
+++ b/kie-soup-commons/src/main/java/org/kie/soup/commons/util/Lists.java
@@ -17,6 +17,7 @@
 package org.kie.soup.commons.util;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class Lists {
@@ -30,6 +31,16 @@ public class Lists {
 
         public Lists.Builder<E> add(E e) {
             result.add(e);
+            return this;
+        }
+
+        public Lists.Builder<E> addAll(List<E> elements) {
+            result.addAll(elements);
+            return this;
+        }
+
+        public Lists.Builder<E> addAll(Collection<E> elements) {
+            result.addAll(elements);
             return this;
         }
 

--- a/kie-soup-commons/src/test/java/org/kie/soup/commons/util/ListsTest.java
+++ b/kie-soup-commons/src/test/java/org/kie/soup/commons/util/ListsTest.java
@@ -16,10 +16,14 @@
 
 package org.kie.soup.commons.util;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -58,5 +62,32 @@ public class ListsTest {
         assertEquals(2, list.size());
         assertTrue(list.contains(E_1));
         assertTrue(list.contains(E_2));
+    }
+
+    @Test
+    public void testAddAll() {
+        List<String> strings = new ArrayList<>();
+        strings.add("first");
+        strings.add("second");
+        strings.add("third");
+
+        List<String> tested = new Lists.Builder<String>()
+                .addAll(strings).build();
+
+        assertEquals(strings, tested);
+    }
+
+    @Test
+    public void testAddAllFromCollection() {
+        Collection<String> strings = new HashSet<>();
+        strings.add("first");
+        strings.add("second");
+        strings.add("third");
+
+        List<String> tested = new Lists.Builder<String>()
+                .addAll(strings).build();
+
+        assertThat(tested).containsSequence(strings);
+        assertThat(tested.size()).isEqualTo(strings.size());
     }
 }


### PR DESCRIPTION
Hi @romartin, @manstis,

I added `addAll` method for Lists Builder to make it easier to minimize amount of generated classes.