### PR TITLE
JBPM-8559 - Avoid estimating query and table row counts and use prepared statement for reading columns metadata (#91)

### DIFF
--- a/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/SQLDataSetDef.java
+++ b/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/def/SQLDataSetDef.java
@@ -39,6 +39,8 @@ public class SQLDataSetDef extends DataSetDef {
     @NotNull(groups = {SQLDataSetDefDbSQLValidation.class})
     @Size(min = 1, groups = {SQLDataSetDefDbSQLValidation.class})
     protected String dbSQL;
+    
+    protected boolean estimateSize = true;
 
     public SQLDataSetDef() {
         super.setProvider(DataSetProviderType.SQL);
@@ -92,6 +94,14 @@ public class SQLDataSetDef extends DataSetDef {
         this.cacheMaxRows = cacheMaxRows;
     }
 
+    public void setEstimateSize(boolean estimateSize) {
+        this.estimateSize = estimateSize;
+    }
+
+    public boolean isEstimateSize() {
+        return estimateSize;
+    }
+
     @Override
     public boolean equals(Object obj) {
         try {
@@ -109,6 +119,9 @@ public class SQLDataSetDef extends DataSetDef {
                 return false;
             }
             if (dbSQL != null && !dbSQL.equals(other.dbSQL)) {
+                return false;
+            }
+            if(estimateSize != other.estimateSize){
                 return false;
             }
             return true;
@@ -134,6 +147,7 @@ public class SQLDataSetDef extends DataSetDef {
         def.setDbSchema(getDbSchema());
         def.setDbTable(getDbTable());
         def.setDbSQL(getDbSQL());
+        def.setEstimateSize(isEstimateSize());
         return def;
     }
 
@@ -155,6 +169,7 @@ public class SQLDataSetDef extends DataSetDef {
         out.append("Get all columns=").append(allColumnsEnabled).append("\n");
         out.append("Cache enabled=").append(cacheEnabled).append("\n");
         out.append("Cache max rows=").append(cacheMaxRows).append(" Kb\n");
+        out.append("Estimate size=").append(estimateSize).append("\n");
         return out.toString();
     }
 }

--- a/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/impl/SQLDataSetDefBuilderImpl.java
+++ b/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/impl/SQLDataSetDefBuilderImpl.java
@@ -46,4 +46,9 @@ public class SQLDataSetDefBuilderImpl extends AbstractDataSetDefBuilder<SQLDataS
         ((SQLDataSetDef) def).setAllColumnsEnabled(allColumns);
         return this;
     }
+
+    public SQLDataSetDefBuilderImpl estimateSize(boolean estimateSize) {
+        ((SQLDataSetDef) def).setEstimateSize(estimateSize);
+        return this;
+    }
 }

--- a/kie-soup-dataset/kie-soup-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/SQLDataSetDefTest.java
+++ b/kie-soup-dataset/kie-soup-dataset-sql/src/test/java/org/dashbuilder/dataprovider/sql/SQLDataSetDefTest.java
@@ -61,12 +61,27 @@ public class SQLDataSetDefTest extends SQLDataSetTestBase {
         DataSetMetadata metadata = dataSetManager.getDataSetMetadata("expense_reports_allcolumns");
         assertThat(metadata.getNumberOfColumns()).isEqualTo(6);
         assertThat(metadata.getEstimatedSize()).isEqualTo(6350);
+        assertThat(metadata.getNumberOfRows()).isEqualTo(50);
+    }
+
+    @Test
+    public void testNoEstimateSize() throws Exception {
+        URL fileURL = Thread.currentThread().getContextClassLoader().getResource("expenseReports_allcolumns.dset");
+        String json = IOUtils.toString(fileURL, StandardCharsets.UTF_8);
+        SQLDataSetDef def = (SQLDataSetDef) jsonMarshaller.fromJson(json);
+        def.setEstimateSize(false);
+        dataSetDefRegistry.registerDataSetDef(def);
+
+        DataSetMetadata metadata = dataSetManager.getDataSetMetadata("expense_reports_allcolumns");
+        assertThat(metadata.getNumberOfColumns()).isEqualTo(6);
+        assertThat(metadata.getEstimatedSize()).isEqualTo(0);
+        assertThat(metadata.getNumberOfRows()).isEqualTo(0);
     }
 
     @Test
     public void testSQLDataSet() throws Exception {
-        String testDsetFile = testSettings.getExpenseReportsSqlDsetFile();
-        URL fileURL = Thread.currentThread().getContextClassLoader().getResource(testDsetFile);
+        String testDataSetFile = testSettings.getExpenseReportsSqlDsetFile();
+        URL fileURL = Thread.currentThread().getContextClassLoader().getResource(testDataSetFile);
         String json = IOUtils.toString(fileURL, StandardCharsets.UTF_8);
         SQLDataSetDef def = (SQLDataSetDef) jsonMarshaller.fromJson(json);
         dataSetDefRegistry.registerDataSetDef(def);
@@ -74,6 +89,7 @@ public class SQLDataSetDefTest extends SQLDataSetTestBase {
         DataSetMetadata metadata = dataSetManager.getDataSetMetadata("expense_reports_sql");
         assertThat(metadata.getNumberOfColumns()).isEqualTo(3);
         assertThat(metadata.getNumberOfRows()).isEqualTo(6);
+        assertThat(metadata.getEstimatedSize()).isEqualTo(342);
 
         final String uuid = "expense_reports_sql";
         DataSet dataSet = dataSetManager.lookupDataSet(
@@ -104,6 +120,7 @@ public class SQLDataSetDefTest extends SQLDataSetTestBase {
         assertThat(metadata.getNumberOfColumns()).isEqualTo(4);
         if (!testSettings.isMonetDB()) {
             assertThat(metadata.getEstimatedSize()).isEqualTo(4300);
+            assertThat(metadata.getNumberOfRows()).isEqualTo(50);
         }
 
         final String uuid = "expense_reports_columnset";
@@ -164,6 +181,7 @@ public class SQLDataSetDefTest extends SQLDataSetTestBase {
         assertThat(metadata.getNumberOfColumns()).isEqualTo(5);
         if (!testSettings.isMonetDB()) {
             assertThat(metadata.getEstimatedSize()).isEqualTo(666);
+            assertThat(metadata.getNumberOfRows()).isEqualTo(6);
         }
 
         DataSet dataSet = dataSetManager.lookupDataSet(


### PR DESCRIPTION
backport targetting 7.4.1
https://issues.jboss.org/browse/RHPAM-2169