### PR TITLE
BXMSPROD-8: refactor to build without jboss-ip-bom

### DIFF
--- a/kie-soup-bom/pom.xml
+++ b/kie-soup-bom/pom.xml
@@ -20,11 +20,10 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jboss.integration-platform</groupId>
-    <artifactId>jboss-integration-platform-parent</artifactId>
-    <!-- Keep in sync with the parent version of ../pom.xml -->
-    <version>8.6.0.Final</version>
-    <relativePath/>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-parent</artifactId>
+    <version>7.24.0-SNAPSHOT</version>
+    <!-- Keep in sync with the parent version in ../pom.xml (kie-parent)  -->
   </parent>
 
   <groupId>org.kie.soup</groupId>

--- a/kie-soup-dataset/kie-soup-dataset-core/src/test/java/org/dashbuilder/dataset/DataSetDefRegistryTest.java
+++ b/kie-soup-dataset/kie-soup-dataset-core/src/test/java/org/dashbuilder/dataset/DataSetDefRegistryTest.java
@@ -21,7 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;

--- a/kie-soup-dataset/kie-soup-dataset-sql-tests/pom.xml
+++ b/kie-soup-dataset/kie-soup-dataset-sql-tests/pom.xml
@@ -178,7 +178,26 @@
           </additionalClasspathElements>
         </configuration>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-install</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,13 +18,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <!-- Does not have kie-parent because that would cause circular dependency.
-       Change to kie-parent and remove version properties when UberFire moves to kiegroup. -->
   <parent>
-    <groupId>org.jboss.integration-platform</groupId>
-    <artifactId>jboss-integration-platform-bom</artifactId>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-parent</artifactId>
+    <version>7.24.0-SNAPSHOT</version>
     <!-- Keep in sync with the parent version of kie-soup-bom/pom.xml -->
-    <version>8.6.0.Final</version>
   </parent>
 
   <groupId>org.kie.soup</groupId>
@@ -114,10 +112,12 @@
   <build>
     <pluginManagement>
       <plugins>
+        
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <dependencies>
+	  <version>${version.enforcer.plugin}</version>
+	  <dependencies>
             <dependency>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>extra-enforcer-rules</artifactId>
@@ -266,7 +266,8 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <executions>
+	  <version>${version.failsafe.plugin}</version>
+	  <executions>
             <execution>
               <goals>
                 <goal>integration-test</goal>
@@ -548,6 +549,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-platform-bom</artifactId>
+	    <version>${project.version}</version>
+	    <type>pom</type>
+	    <scope>import</scope>
+      </dependency>		  
       <dependency>
         <groupId>org.kie.soup</groupId>
         <artifactId>kie-soup-bom</artifactId>


### PR DESCRIPTION
changed GAV since ...junit... is deprecated in the new mockito version

disabled maven-jar-plugin

upgraded missing versions to 7.24.0-SNAPSHOT