### PR TITLE
revoked the disabling of maven-jar-plugin

### DIFF
--- a/kie-soup-dataset/kie-soup-dataset-sql-tests/pom.xml
+++ b/kie-soup-dataset/kie-soup-dataset-sql-tests/pom.xml
@@ -178,26 +178,6 @@
           </additionalClasspathElements>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-jar</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-install</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
enabled the maven-jar-plugin again because the disabling of it causes much more problems then the problem:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-jar-plugin:3.1.0:jar (default-jar) on project appformer-js: You have to use a classifier to attach supplemental artifacts to the project instead of replacing them. -> [Help 1]

This error has to solved ASAP.