### PR TITLE
Add module names properties

### DIFF
--- a/kie-soup-commons/pom.xml
+++ b/kie-soup-commons/pom.xml
@@ -32,6 +32,10 @@
   <name>KIE Soup Commons</name>
   <description>Collection of reusable (not depending on any other KIE Soup module) components for KIE Soup.</description>
 
+  <properties>
+    <java.module.name>org.kie.soup.commons</java.module.name>
+  </properties>
+
   <dependencies>
 
     <!-- NOTE TO MAINTAINERS: This module is used by UberFire's VFS, which must remain independent of "web" technologies.

--- a/kie-soup-maven-utils/kie-soup-maven-support/pom.xml
+++ b/kie-soup-maven-utils/kie-soup-maven-support/pom.xml
@@ -14,6 +14,10 @@
 
   <name>Maven-support</name>
 
+  <properties>
+    <java.module.name>org.kie.soup.maven.support</java.module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/kie-soup-project-datamodel/kie-soup-project-datamodel-api/pom.xml
+++ b/kie-soup-project-datamodel/kie-soup-project-datamodel-api/pom.xml
@@ -32,7 +32,7 @@
   <name>Project Datamodel API</name>
 
   <properties>
-    <osgi.Bundle-SymbolicName>org.kie.soup.project.datamodel</osgi.Bundle-SymbolicName>
+    <java.module.name>org.kie.soup.project.datamodel</java.module.name>
   </properties>
 
   <build>

--- a/kie-soup-project-datamodel/kie-soup-project-datamodel-commons/pom.xml
+++ b/kie-soup-project-datamodel/kie-soup-project-datamodel-commons/pom.xml
@@ -32,7 +32,7 @@
   <name>Project DataModel - Commons</name>
 
   <properties>
-    <osgi.Bundle-SymbolicName>org.kie.soup.project.datamodel.commons</osgi.Bundle-SymbolicName>
+    <java.module.name>org.kie.soup.project.datamodel.commons</java.module.name>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Module names properties are required by Maven bundle plugin to correctly set
bundle symbolic names.