### PR TITLE
RHPAM-2517: removed duplicated version properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,10 +51,8 @@
     <!-- Required since support for ELS 2.x. Keep in sync with kie-parent or remove when those
           two versions are being updated on the IP BOM.-->
     <version.com.googlecode.jsonsimple>1.1.1</version.com.googlecode.jsonsimple>
-    <version.org.mvel>2.3.2.Final</version.org.mvel>
     <version.org.elasticsearch>5.6.1</version.org.elasticsearch>
     <version.org.apache.lucene>6.6.1</version.org.apache.lucene>
-    <version.io.netty.old>3.10.6.Final</version.io.netty.old>
     <version.com.github.tdomzal.junit.docker>0.3</version.com.github.tdomzal.junit.docker>
     <version.com.spotify.docker.client>5.0.2</version.com.spotify.docker.client>
     <version.org.apache.logging.log4j>2.8.2</version.org.apache.logging.log4j>
@@ -554,11 +552,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.mvel</groupId>
-        <artifactId>mvel2</artifactId>
-        <version>${version.org.mvel}</version>
-      </dependency>
       <!-- Elastic search and transitive dependencies for it. -->
       <dependency>
         <groupId>org.elasticsearch</groupId>
@@ -575,11 +568,6 @@
             <groupId>commons-logging</groupId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty</artifactId>
-        <version>${version.io.netty.old}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.lucene</groupId>


### PR DESCRIPTION
related issue where duplicated version property causes the usage of old mvel2

I additionaly removed netty version property which is now in KIE-PARENT too

https://issues.jboss.org/browse/RHPAM-2517