### PR TITLE
KOGITO-1546 XStreamUtils kie-soup refactoring

### DIFF
--- a/kie-soup-xstream/pom.xml
+++ b/kie-soup-xstream/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.soup</groupId>
     <artifactId>kie-soup-parent</artifactId>
-    <version>7.37.0-SNAPSHOT</version>
+    <version>7.38.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kie-soup-xstream/pom.xml
+++ b/kie-soup-xstream/pom.xml
@@ -22,18 +22,18 @@
   <parent>
     <groupId>org.kie.soup</groupId>
     <artifactId>kie-soup-parent</artifactId>
-    <version>7.38.0-SNAPSHOT</version>
+    <version>7.37.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>kie-soup-commons</artifactId>
+  <artifactId>kie-soup-xstream</artifactId>
   <packaging>bundle</packaging>
 
-  <name>KIE Soup Commons</name>
-  <description>Collection of reusable (not depending on any other KIE Soup module) components for KIE Soup.</description>
+  <name>KIE Soup XStream</name>
+  <description>Collection of XStream utilities (not depending on any other KIE Soup module) for KIE Soup.</description>
 
   <properties>
-    <java.module.name>org.kie.soup.commons</java.module.name>
+    <java.module.name>org.kie.soup.xstream</java.module.name>
   </properties>
 
   <dependencies>
@@ -42,8 +42,8 @@
          Don't add dependencies from this module to any other UberFire or Errai module! See UF-131 and UF-135 for details. -->
 
     <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -71,11 +71,12 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Bundle-SymbolicName>org.kie.soup.commons</Bundle-SymbolicName>
+            <Bundle-SymbolicName>org.kie.soup.xstream</Bundle-SymbolicName>
             <Export-Package>
-              org.kie.soup.commons.*
+              org.kie.soup.xstream.*
             </Export-Package>
             <Import-Package>
+              com.thoughtworks.xstream.*;resolution:=optional,
               *
             </Import-Package>
             <_removeheaders>Private-Package</_removeheaders>

--- a/kie-soup-xstream/src/main/java/org/kie/soup/xstream/AnyAnnotationTypePermission.java
+++ b/kie-soup-xstream/src/main/java/org/kie/soup/xstream/AnyAnnotationTypePermission.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.kie.soup.commons.xstream;
+package org.kie.soup.xstream;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAliasType;

--- a/kie-soup-xstream/src/main/java/org/kie/soup/xstream/LocalDateTimeXStreamConverter.java
+++ b/kie-soup-xstream/src/main/java/org/kie/soup/xstream/LocalDateTimeXStreamConverter.java
@@ -13,10 +13,10 @@
  * limitations under the License.
 */
 
-package org.kie.soup.commons.xstream;
+package org.kie.soup.xstream;
 
 import java.time.DateTimeException;
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
@@ -32,38 +32,37 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
  *
  * @see <a href="https://github.com/x-stream/xstream/issues/75">XStream#75</a>
  */
-public class OffsetDateTimeXStreamConverter implements Converter {
+public class LocalDateTimeXStreamConverter implements Converter {
 
     private final DateTimeFormatter formatter;
 
-    public OffsetDateTimeXStreamConverter() {
+    public LocalDateTimeXStreamConverter() {
         formatter = new DateTimeFormatterBuilder()
                 .appendPattern( "uuuu-MM-dd'T'HH:mm:ss" )
                 .appendFraction( ChronoField.NANO_OF_SECOND, 0, 9, true )
-                .appendOffsetId()
                 .toFormatter();
     }
 
     @Override
-    public void marshal( Object localTimeObject, HierarchicalStreamWriter writer, MarshallingContext context ) {
-        OffsetDateTime offsetDateTime = (OffsetDateTime) localTimeObject;
-        writer.setValue( formatter.format( offsetDateTime ) );
+    public void marshal( Object localDateTimeObject, HierarchicalStreamWriter writer, MarshallingContext context ) {
+        LocalDateTime localDateTime = (LocalDateTime) localDateTimeObject;
+        writer.setValue( formatter.format( localDateTime ) );
     }
 
     @Override
     public Object unmarshal( HierarchicalStreamReader reader, UnmarshallingContext context ) {
-        String offsetDateTimeString = reader.getValue();
+        String localDateTimeString = reader.getValue();
         try {
-            return OffsetDateTime.from( formatter.parse( offsetDateTimeString ) );
+            return LocalDateTime.from( formatter.parse( localDateTimeString ) );
         } catch ( DateTimeException e ) {
-            throw new IllegalStateException( "Failed to convert string (" + offsetDateTimeString + ") to type ("
-                    + OffsetDateTime.class.getName() + ")." );
+            throw new IllegalStateException( "Failed to convert string (" + localDateTimeString + ") to type ("
+                    + LocalDateTime.class.getName() + ")." );
         }
     }
 
     @Override
     public boolean canConvert( Class type ) {
-        return OffsetDateTime.class.isAssignableFrom( type );
+        return LocalDateTime.class.isAssignableFrom( type );
     }
 
 }

--- a/kie-soup-xstream/src/main/java/org/kie/soup/xstream/LocalDateXStreamConverter.java
+++ b/kie-soup-xstream/src/main/java/org/kie/soup/xstream/LocalDateXStreamConverter.java
@@ -13,13 +13,10 @@
  * limitations under the License.
 */
 
-package org.kie.soup.commons.xstream;
+package org.kie.soup.xstream;
 
 import java.time.DateTimeException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.temporal.ChronoField;
+import java.time.LocalDate;
 
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
@@ -32,37 +29,28 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
  *
  * @see <a href="https://github.com/x-stream/xstream/issues/75">XStream#75</a>
  */
-public class LocalDateTimeXStreamConverter implements Converter {
-
-    private final DateTimeFormatter formatter;
-
-    public LocalDateTimeXStreamConverter() {
-        formatter = new DateTimeFormatterBuilder()
-                .appendPattern( "uuuu-MM-dd'T'HH:mm:ss" )
-                .appendFraction( ChronoField.NANO_OF_SECOND, 0, 9, true )
-                .toFormatter();
-    }
+public class LocalDateXStreamConverter implements Converter {
 
     @Override
-    public void marshal( Object localDateTimeObject, HierarchicalStreamWriter writer, MarshallingContext context ) {
-        LocalDateTime localDateTime = (LocalDateTime) localDateTimeObject;
-        writer.setValue( formatter.format( localDateTime ) );
+    public void marshal( Object localDateObject, HierarchicalStreamWriter writer, MarshallingContext context ) {
+        LocalDate localDate = (LocalDate) localDateObject;
+        writer.setValue( localDate.toString() );
     }
 
     @Override
     public Object unmarshal( HierarchicalStreamReader reader, UnmarshallingContext context ) {
-        String localDateTimeString = reader.getValue();
+        String localDateString = reader.getValue();
         try {
-            return LocalDateTime.from( formatter.parse( localDateTimeString ) );
+            return LocalDate.parse( localDateString );
         } catch ( DateTimeException e ) {
-            throw new IllegalStateException( "Failed to convert string (" + localDateTimeString + ") to type ("
-                    + LocalDateTime.class.getName() + ")." );
+            throw new IllegalStateException( "Failed to convert string (" + localDateString + ") to type ("
+                    + LocalDate.class.getName() + ")." );
         }
     }
 
     @Override
     public boolean canConvert( Class type ) {
-        return LocalDateTime.class.isAssignableFrom( type );
+        return LocalDate.class.isAssignableFrom( type );
     }
 
 }

--- a/kie-soup-xstream/src/main/java/org/kie/soup/xstream/LocalTimeXStreamConverter.java
+++ b/kie-soup-xstream/src/main/java/org/kie/soup/xstream/LocalTimeXStreamConverter.java
@@ -13,7 +13,7 @@
  * limitations under the License.
 */
 
-package org.kie.soup.commons.xstream;
+package org.kie.soup.xstream;
 
 import java.time.DateTimeException;
 import java.time.LocalTime;

--- a/kie-soup-xstream/src/main/java/org/kie/soup/xstream/OffsetDateTimeXStreamConverter.java
+++ b/kie-soup-xstream/src/main/java/org/kie/soup/xstream/OffsetDateTimeXStreamConverter.java
@@ -13,10 +13,13 @@
  * limitations under the License.
 */
 
-package org.kie.soup.commons.xstream;
+package org.kie.soup.xstream;
 
 import java.time.DateTimeException;
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
@@ -29,28 +32,38 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
  *
  * @see <a href="https://github.com/x-stream/xstream/issues/75">XStream#75</a>
  */
-public class LocalDateXStreamConverter implements Converter {
+public class OffsetDateTimeXStreamConverter implements Converter {
+
+    private final DateTimeFormatter formatter;
+
+    public OffsetDateTimeXStreamConverter() {
+        formatter = new DateTimeFormatterBuilder()
+                .appendPattern( "uuuu-MM-dd'T'HH:mm:ss" )
+                .appendFraction( ChronoField.NANO_OF_SECOND, 0, 9, true )
+                .appendOffsetId()
+                .toFormatter();
+    }
 
     @Override
-    public void marshal( Object localDateObject, HierarchicalStreamWriter writer, MarshallingContext context ) {
-        LocalDate localDate = (LocalDate) localDateObject;
-        writer.setValue( localDate.toString() );
+    public void marshal( Object localTimeObject, HierarchicalStreamWriter writer, MarshallingContext context ) {
+        OffsetDateTime offsetDateTime = (OffsetDateTime) localTimeObject;
+        writer.setValue( formatter.format( offsetDateTime ) );
     }
 
     @Override
     public Object unmarshal( HierarchicalStreamReader reader, UnmarshallingContext context ) {
-        String localDateString = reader.getValue();
+        String offsetDateTimeString = reader.getValue();
         try {
-            return LocalDate.parse( localDateString );
+            return OffsetDateTime.from( formatter.parse( offsetDateTimeString ) );
         } catch ( DateTimeException e ) {
-            throw new IllegalStateException( "Failed to convert string (" + localDateString + ") to type ("
-                    + LocalDate.class.getName() + ")." );
+            throw new IllegalStateException( "Failed to convert string (" + offsetDateTimeString + ") to type ("
+                    + OffsetDateTime.class.getName() + ")." );
         }
     }
 
     @Override
     public boolean canConvert( Class type ) {
-        return LocalDate.class.isAssignableFrom( type );
+        return OffsetDateTime.class.isAssignableFrom( type );
     }
 
 }

--- a/kie-soup-xstream/src/main/java/org/kie/soup/xstream/XStreamUtils.java
+++ b/kie-soup-xstream/src/main/java/org/kie/soup/xstream/XStreamUtils.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.soup.commons.xstream;
+package org.kie.soup.xstream;
 
 import java.util.function.Function;
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
 
   <modules>
     <module>kie-soup-commons</module>
+    <module>kie-soup-xstream</module>
     <module>kie-soup-project-datamodel</module>
     <module>kie-soup-maven-utils</module>
     <module>kie-soup-dataset</module>


### PR DESCRIPTION
a suite of PRs:

### drools.git "v7x" stream
[kie-soup] this one
[droolsjbpm-build-bootstrap] https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1286
[appformer] https://github.com/kiegroup/appformer/pull/953
[drools] https://github.com/kiegroup/drools/pull/2874
[jbpm] https://github.com/kiegroup/jbpm/pull/1640
[droolsjbpm-integration] https://github.com/kiegroup/droolsjbpm-integration/pull/2078
[kie-wb-common] https://github.com/kiegroup/kie-wb-common/pull/3288
[drools-wb] https://github.com/kiegroup/drools-wb/pull/1356
[optaplanner-wb] https://github.com/kiegroup/optaplanner-wb/pull/367
[jbpm-wb] https://github.com/kiegroup/jbpm-wb/pull/1430
[kie-wb-playground] https://github.com/kiegroup/kie-wb-playground/pull/86
[droolsjbpm-tools] https://github.com/kiegroup/droolsjbpm-tools/pull/104

1. ALL and each of these PRs ^ have been **successfully** compiled locally before raising the respective PR.
2. These PRs ^ will need be merged at-once.

### Kogito stream
[kogito-runtimes] https://github.com/kiegroup/kogito-runtimes/pull/481

the Kogito stream ^ will need to await a community or tag-release, but it is **not** required to be merged at-once.