### PR TITLE
merged duplicated maven-surefire-plugin configuration

### DIFF
--- a/kie-soup-dataset/kie-soup-dataset-sql-tests/pom.xml
+++ b/kie-soup-dataset/kie-soup-dataset-sql-tests/pom.xml
@@ -173,17 +173,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.15</version>
         <configuration>
           <dependenciesToScan>
             <dependency>org.kie.soup:kie-soup-dataset-sql</dependency>
           </dependenciesToScan>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
           <additionalClasspathElements>
             <additionalClasspathElement>${maven.jdbc.driver.jar}</additionalClasspathElement>
           </additionalClasspathElements>


### PR DESCRIPTION
this was showing in maven build 
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kie.soup:kie-soup-dataset-sql-tests:jar:7.39.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-surefire-plugin @ line 183, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```