### PR TITLE
[DROOLS-5783] Make droolsjbpm-integration repo independent from appformer

### DIFF
--- a/kie-soup-security-utils/pom.xml
+++ b/kie-soup-security-utils/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie.soup</groupId>
+    <artifactId>kie-soup-parent</artifactId>
+    <version>7.46.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>kie-soup-security-utils</artifactId>
+  <packaging>jar</packaging>
+
+  <name>KIE Soup Security Utils</name>
+  <description>Collection of Java security utilities for KIE Soup.</description>
+
+  <properties>
+    <java.module.name>org.kie.soup.security.utils</java.module.name>
+  </properties>
+
+</project>

--- a/kie-soup-security-utils/src/main/java/org/kie/soup/security/utils/BasicAuthorizationPrincipal.java
+++ b/kie-soup-security-utils/src/main/java/org/kie/soup/security/utils/BasicAuthorizationPrincipal.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.soup.security.utils;
+
+import java.security.Principal;
+
+public class BasicAuthorizationPrincipal implements Principal {
+
+    private final String name;
+
+    public BasicAuthorizationPrincipal(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
     <module>kie-soup-project-datamodel</module>
     <module>kie-soup-maven-utils</module>
     <module>kie-soup-dataset</module>
+    <module>kie-soup-security-utils</module>
   </modules>
 
   <build>


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-5783

Description:
The goal of this PR is to cleanup `droolsjbpm-integration` repo from unnecessary relation with other repos (in this case `appformer`). It is a sort of followup of this PR https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1505 that tries to do the same but it has been partially reverted because of some remaining usages

Details of this part of the PR:
- adding `kie-soup-security-utils` to share `BasicAuthorizationPrincipal` impl

@mareknovotny @Ginxo @lucamolteni @mariofusco 

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1517
* https://github.com/kiegroup/kie-soup/pull/163
* https://github.com/kiegroup/appformer/pull/1073
* https://github.com/kiegroup/droolsjbpm-integration/pull/2306
* https://github.com/kiegroup/kie-wb-common/pull/3472

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
