### PR TITLE
DROOLS-5883: Allow contains operator for string fields

### DIFF
--- a/kie-soup-project-datamodel/kie-soup-project-datamodel-api/src/main/java/org/kie/soup/project/datamodel/oracle/OperatorsOracle.java
+++ b/kie-soup-project-datamodel/kie-soup-project-datamodel-api/src/main/java/org/kie/soup/project/datamodel/oracle/OperatorsOracle.java
@@ -36,7 +36,7 @@ public class OperatorsOracle {
 
     public static final String[] COMPARABLE_CONNECTIVES = new String[]{ "|| ==", "|| !=", "&& !=", "&& >", "&& <", "|| >", "|| <", "&& >=", "&& <=", "|| <=", "|| >=" };
 
-    public static final String[] STRING_OPERATORS = new String[]{ "==", "!=", "<", ">", "<=", ">=", "matches", "not matches", "soundslike", "not soundslike", "== null", "!= null" };
+    public static final String[] STRING_OPERATORS = new String[]{ "==", "!=", "<", ">", "<=", ">=", "contains", "matches", "not matches", "soundslike", "not soundslike", "== null", "!= null" };
 
     public static final String[] STRING_CONNECTIVES = new String[]{ "|| ==", "|| !=", "&& !=", "&& >", "&& <", "|| >", "|| <", "&& >=", "&& <=", "|| <=", "|| >=", "&& matches", "|| matches" };
 

--- a/kie-soup-project-datamodel/kie-soup-project-datamodel-api/src/main/java/org/kie/soup/project/datamodel/oracle/OperatorsOracle.java
+++ b/kie-soup-project-datamodel/kie-soup-project-datamodel-api/src/main/java/org/kie/soup/project/datamodel/oracle/OperatorsOracle.java
@@ -36,7 +36,9 @@ public class OperatorsOracle {
 
     public static final String[] COMPARABLE_CONNECTIVES = new String[]{ "|| ==", "|| !=", "&& !=", "&& >", "&& <", "|| >", "|| <", "&& >=", "&& <=", "|| <=", "|| >=" };
 
-    public static final String[] STRING_OPERATORS = new String[]{ "==", "!=", "<", ">", "<=", ">=", "contains", "matches", "not matches", "soundslike", "not soundslike", "== null", "!= null" };
+    public static final String[] STRING_OPERATORS = new String[]{"==", "!=", "<", ">", "<=", ">=",
+            "contains", "not contains", "matches", "not matches", "soundslike", "not soundslike",
+            "== null", "!= null"};
 
     public static final String[] STRING_CONNECTIVES = new String[]{ "|| ==", "|| !=", "&& !=", "&& >", "&& <", "|| >", "|| <", "&& >=", "&& <=", "|| <=", "|| >=", "&& matches", "|| matches" };
 

--- a/kie-soup-project-datamodel/kie-soup-project-datamodel-api/src/test/java/org/kie/soup/project/datamodel/OperatorsOracleTest.java
+++ b/kie-soup-project-datamodel/kie-soup-project-datamodel-api/src/test/java/org/kie/soup/project/datamodel/OperatorsOracleTest.java
@@ -98,7 +98,7 @@ public class OperatorsOracleTest {
 
     @Test
     public void stringOperators() {
-        assertContainsAll(OperatorsOracle.STRING_OPERATORS, "==", "!=", "<", ">", "<=", ">=", "matches", "not matches", "soundslike", "not soundslike", "== null", "!= null");
+        assertContainsAll(OperatorsOracle.STRING_OPERATORS, "==", "!=", "<", ">", "<=", ">=", "contains", "matches", "not matches", "soundslike", "not soundslike", "== null", "!= null");
     }
 
     public void assertContainsAll(final String[] list, String... items) {

--- a/kie-soup-project-datamodel/kie-soup-project-datamodel-api/src/test/java/org/kie/soup/project/datamodel/OperatorsOracleTest.java
+++ b/kie-soup-project-datamodel/kie-soup-project-datamodel-api/src/test/java/org/kie/soup/project/datamodel/OperatorsOracleTest.java
@@ -98,7 +98,9 @@ public class OperatorsOracleTest {
 
     @Test
     public void stringOperators() {
-        assertContainsAll(OperatorsOracle.STRING_OPERATORS, "==", "!=", "<", ">", "<=", ">=", "contains", "matches", "not matches", "soundslike", "not soundslike", "== null", "!= null");
+        assertContainsAll(OperatorsOracle.STRING_OPERATORS, "==", "!=", "<", ">", "<=", ">=",
+                          "contains", "not contains", "matches", "not matches", "soundslike", "not soundslike",
+                          "== null", "!= null");
     }
 
     public void assertContainsAll(final String[] list, String... items) {


### PR DESCRIPTION
Guided decision table and guided rule editor will ofer 'contains' operator also for string fields

For more details see https://issues.redhat.com/browse/DROOLS-5883

Ensemble together with:
- https://github.com/kiegroup/drools/pull/3281
- https://github.com/kiegroup/drools-wb/pull/1448