### PR TITLE
Remove unnecessary mock

### DIFF
--- a/kie-soup-dataset/kie-soup-dataset-prometheus/src/test/java/org/dashbuilder/dataprovider/prometheus/client/PrometheusClientTest.java
+++ b/kie-soup-dataset/kie-soup-dataset-prometheus/src/test/java/org/dashbuilder/dataprovider/prometheus/client/PrometheusClientTest.java
@@ -44,7 +44,6 @@ public class PrometheusClientTest {
     @Before
     public void setup() {
         prometheusClient.setBaseUrl(BASE_URL);
-        when(httpClient.doGet(any())).thenReturn("{}");
     }
 
     @Test


### PR DESCRIPTION
Due Mockito update an exception is thrown in cases where unnecessary mocks were made (mocks that are not reached)