### PR TITLE
[7.48.x] DROOLS-6033 : LocaldateTime guided rule presents it incorrectly.

### DIFF
--- a/kie-soup-project-datamodel/kie-soup-project-datamodel-api/src/main/java/org/kie/soup/project/datamodel/oracle/DataType.java
+++ b/kie-soup-project-datamodel/kie-soup-project-datamodel-api/src/main/java/org/kie/soup/project/datamodel/oracle/DataType.java
@@ -43,6 +43,7 @@ public class DataType {
     public static final String TYPE_BOOLEAN = "Boolean";
     public static final String TYPE_DATE = "Date";
     public static final String TYPE_LOCAL_DATE = "LocalDate";
+    public static final String TYPE_LOCAL_DATE_TIME = "LocalDateTime";
     public static final String TYPE_OBJECT = "Object";                                                                                                                                                      // for all other unknown
     public static final String TYPE_FINAL_OBJECT = "FinalObject";                                                                                                                                                 // for all other unknown
     public static final String TYPE_THIS = "this";
@@ -88,6 +89,6 @@ public class DataType {
     }
 
     public static boolean isDate(final String type) {
-        return Objects.equals(type, DataType.TYPE_DATE) || Objects.equals(type, DataType.TYPE_LOCAL_DATE);
+        return Objects.equals(type, DataType.TYPE_DATE) || Objects.equals(type, DataType.TYPE_LOCAL_DATE) || Objects.equals(type, DataType.TYPE_LOCAL_DATE_TIME);
     }
 }

--- a/kie-soup-project-datamodel/kie-soup-project-datamodel-api/src/test/java/org/kie/soup/project/datamodel/oracle/DataTypeTest.java
+++ b/kie-soup-project-datamodel/kie-soup-project-datamodel-api/src/test/java/org/kie/soup/project/datamodel/oracle/DataTypeTest.java
@@ -45,6 +45,7 @@ public class DataTypeTest {
                 { DataType.TYPE_COMPARABLE, false, false },
                 { DataType.TYPE_DATE, false, true },
                 { DataType.TYPE_LOCAL_DATE, false, true },
+                { DataType.TYPE_LOCAL_DATE_TIME, false, true },
                 { DataType.TYPE_FINAL_OBJECT, false, false },
                 { DataType.TYPE_OBJECT, false, false },
                 { DataType.TYPE_STRING, false, false },


### PR DESCRIPTION
(cherry picked from commit a26296b9b2d37e9ba4979afad2619c8f88509923)

**JIRA**: [DROOLS-6033](https://issues.redhat.com/browse/DROOLS-6033)

**Referenced Pull Requests**:
* https://github.com/kiegroup/kie-soup/pull/185
* https://github.com/kiegroup/kie-wb-common/pull/3585

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* Retest PR: <b>jenkins retest this</b>
* A full downstream build: <b>jenkins do fdb</b>
* A compile downstream build: <b>jenkins do cdb</b>
* A full production downstream build: <b>jenkins do product fdb</b>
* An upstream build: <b>jenkins do upstream</b>
</details>
