### PR TITLE
JBPM-9678: Standalone workbench does not start

### DIFF
--- a/kie-soup-dataset/kie-soup-dataset-kafka/src/main/java/org/dashbuilder/dataprovider/kafka/mbean/JMXRMIConnectorProvider.java
+++ b/kie-soup-dataset/kie-soup-dataset-kafka/src/main/java/org/dashbuilder/dataprovider/kafka/mbean/JMXRMIConnectorProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.dataprovider.kafka.mbean;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorProvider;
+import javax.management.remote.JMXServiceURL;
+import javax.management.remote.rmi.RMIConnector;
+
+/**
+ * JMX RMI Connector provider to avoid reflection and other providers to be invoked.
+ *
+ */
+public class JMXRMIConnectorProvider implements JMXConnectorProvider {
+
+    @Override
+    public JMXConnector newJMXConnector(JMXServiceURL serviceURL, Map<String, ?> environment) throws IOException {
+        return new RMIConnector(serviceURL, environment);
+    }
+
+}

--- a/kie-soup-dataset/kie-soup-dataset-kafka/src/main/java/org/dashbuilder/dataprovider/kafka/mbean/MBeanServerConnectionProvider.java
+++ b/kie-soup-dataset/kie-soup-dataset-kafka/src/main/java/org/dashbuilder/dataprovider/kafka/mbean/MBeanServerConnectionProvider.java
@@ -15,8 +15,9 @@
  */
 package org.dashbuilder.dataprovider.kafka.mbean;
 
+import java.util.Collections;
+
 import javax.management.remote.JMXConnector;
-import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 
 import org.dashbuilder.dataprovider.kafka.model.KafkaMetricsRequest;
@@ -24,6 +25,7 @@ import org.dashbuilder.dataprovider.kafka.model.KafkaMetricsRequest;
 public class MBeanServerConnectionProvider {
 
     private static final String RMI_URL_TEMPLATE = "service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi";
+    private static final JMXRMIConnectorProvider PROVIDER = new JMXRMIConnectorProvider();
 
     private MBeanServerConnectionProvider() {
         // do nothing
@@ -36,7 +38,9 @@ public class MBeanServerConnectionProvider {
             validateParams(host, port);
             String formattedUrl = String.format(RMI_URL_TEMPLATE, host, port);
             JMXServiceURL url = new JMXServiceURL(formattedUrl);
-            return JMXConnectorFactory.connect(url);
+            JMXConnector connector = PROVIDER.newJMXConnector(url, Collections.emptyMap());
+            connector.connect();
+            return connector;
         } catch (Exception e) {
             throw new IllegalArgumentException("Not able to connect to provided server.", e);
         }


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/JBPM-9678

Part of an Ensemble, merge with:

https://github.com/kiegroup/kie-wb-distributions/pull/1092
https://github.com/kiegroup/appformer/pull/1122

How to test:

* Using Business Central create a Kafka data set. See this PR for more information: https://github.com/kiegroup/appformer/pull/1104
* Try the same with thorntail distribution

Description:

For Kafka Data Set providers we have to open RMI connections. With pure Java that's not the problem because all JVM have a default RMI connector provider that can be used for MBeans remote invocation. 
However, in EAP JBoss will try to set its own provider, see the module "org.jboss.remoting-jmx" the code is in [1]. All would be great but the module that contains the JMX connector is not a module added by default to WAR deployments, so we had to declare it in jboss-deployment-structure.xml  - we can't simply ignore it because at some point this connector provider is registered. 
It worked, but broke the thorntail dist. The reason is that it builds a JAR which does not contain all modules. So the deployment broke. Reproducing:

* On master run `mvn clean install` on `business-central-webapp`
* Run: `java -jar ./target/business-central-webapp-thorntail.jar -s sample-standalone-config.yml`

You should see:
```
Caused by: org.jboss.modules.ModuleNotFoundException: org.jboss.remoting-jmx
```
Possible solutions:
1) Find a way to add this module to the thorntail deployment
2) Change the client used by kafka provider (see [2]) to use the standard RMI connector and remove the dependency from jboss-deployment-structure.xml (in dashbuilder-runtime, dashbuilder-webapp and in kie-wb-distribution)
3) Add the dependency [1]  to the deployment and remove the module dependency
4) Create a RMI connector for the Kafka Provider

 I went for 4 because I wanted to get rid of JMXConnectorFactory [3] because it uses reflection and we may have issues when using it with native Quarkus

[1] https://github.com/jbossas/remoting-jmx
[2] https://github.com/kiegroup/kie-soup/blob/master/kie-soup-dataset/kie-soup-dataset-kafka/src/main/java/org/dashbuilder/dataprovider/kafka/mbean/MBeanServerConnectionProvider.java#L38[3] https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXConnectorFactory.html