### PR TITLE
AF-2848: Replacement of org.jboss.spec.javax.* deps

### DIFF
--- a/kie-soup-dataset/kie-soup-dataset-sql-tests/pom.xml
+++ b/kie-soup-dataset/kie-soup-dataset-sql-tests/pom.xml
@@ -119,8 +119,8 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.javax.transaction</groupId>
-      <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+      <groupId>jakarta.transaction</groupId>
+      <artifactId>jakarta.transaction-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.narayana.jta</groupId>


### PR DESCRIPTION
[droolsjbpm-build-bootstrap](https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1626)
[kie-soup](https://github.com/kiegroup/kie-soup/pull/205)
[droolsjbpm-knowledge](https://github.com/kiegroup/droolsjbpm-knowledge/pull/521)
[drools](https://github.com/kiegroup/drools/pull/3628)
[optaplanner](https://github.com/kiegroup/optaplanner/pull/1333)
[appformer](https://github.com/kiegroup/appformer/pull/1143)
[jbpm](https://github.com/kiegroup/jbpm/pull/1917)
[kie-jpmml-integration](https://github.com/kiegroup/kie-jpmml-integration/pull/54)
[jbpm-wb](https://github.com/kiegroup/jbpm-wb/pull/1489)