### PR TITLE
[RHPAM-3856] business central can't start when wildcard host is set t…

### DIFF
--- a/kie-soup-maven-utils/kie-soup-maven-integration/src/main/java/org/appformer/maven/integration/MavenRepositoryConfiguration.java
+++ b/kie-soup-maven-utils/kie-soup-maven-integration/src/main/java/org/appformer/maven/integration/MavenRepositoryConfiguration.java
@@ -230,8 +230,10 @@ public class MavenRepositoryConfiguration {
     }
 
     private static boolean repositoryUrlMatchNonProxyHosts (String nonProxyHosts, String artifactURL) {
+        // Replace * with .* so nonProxyHosts comply with pattern matching syntax
+        String nonProxyHostsRegexp = nonProxyHosts.replace("*", ".*");
         try {
-            Pattern p = Pattern.compile(nonProxyHosts);
+            Pattern p = Pattern.compile(nonProxyHostsRegexp);
             URL url = new URL(artifactURL);
             return p.matcher(url.getHost()).find();
         } catch (MalformedURLException e) {

--- a/kie-soup-maven-utils/kie-soup-maven-integration/src/test/java/org/appformer/maven/integration/MavenRepositoryTest.java
+++ b/kie-soup-maven-utils/kie-soup-maven-integration/src/test/java/org/appformer/maven/integration/MavenRepositoryTest.java
@@ -72,7 +72,7 @@ public class MavenRepositoryTest {
                 .filter(r -> r.getId().contains("kie-wb-m2-repo"))
                 .collect(Collectors.toSet());
 
-        assertEquals(2, proxiedRepos.size());
+        assertEquals(3, proxiedRepos.size());
 
         for (RemoteRepository r : proxiedRepos) {
             if (r.getId().equals("kie-wb-m2-repo-1")) {
@@ -82,6 +82,10 @@ public class MavenRepositoryTest {
             if (r.getId().equals("kie-wb-m2-repo-2" )) {
                 assertEquals("http://www.foo.org", r.getUrl());
                 assertEquals("10.10.10.10:3128",r.getProxy().toString());
+            }
+            if (r.getId().equals("kie-wb-m2-repo-3" )) {
+                assertEquals("http://www.bar.org", r.getUrl());
+                assertNull(r.getProxy());
             }
         }
     }

--- a/kie-soup-maven-utils/kie-soup-maven-integration/src/test/resources/org/appformer/maven/integration/settings_with_proxy.xml
+++ b/kie-soup-maven-utils/kie-soup-maven-integration/src/test/resources/org/appformer/maven/integration/settings_with_proxy.xml
@@ -8,7 +8,7 @@
       <protocol>http</protocol>
       <host>10.10.10.10</host>
       <port>3128</port>
-      <nonProxyHosts>localhost|127*</nonProxyHosts>
+      <nonProxyHosts>localhost|127*|*.bar.org|1.2.3.4</nonProxyHosts>
     </proxy>
   </proxies>
 
@@ -31,6 +31,14 @@
           <id>kie-wb-m2-repo-2</id>
           <name>foo Repo</name>
           <url>http://www.foo.org</url>
+          <snapshots>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>kie-wb-m2-repo-3</id>
+          <name>bar Repo</name>
+          <url>http://www.bar.org</url>
           <snapshots>
             <updatePolicy>always</updatePolicy>
           </snapshots>


### PR DESCRIPTION
…o nonProxyHosts in settings.xml
See: https://issues.redhat.com/browse/RHPAM-3856

Signed-off-by: Karel Suta <ksuta@redhat.com>

Maven nonProxyHosts use similar expression resolving as Java nonProxyHosts [1]
Java use only * for pattern matching in expressions [2]


[1] https://maven.apache.org/guides/mini/guide-proxies.html
[2] https://docs.oracle.com/javase/8/docs/api/java/net/doc-files/net-properties.html