### PR TITLE
KOGITO-6404: Remove unused loggers in Dashbuilder

### DIFF
--- a/kie-soup-dataset/kie-soup-dataset-elasticsearch/pom.xml
+++ b/kie-soup-dataset/kie-soup-dataset-elasticsearch/pom.xml
@@ -207,19 +207,6 @@
       <scope>test</scope>
     </dependency>
 
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>


### PR DESCRIPTION
KOGITO-6404: Remove unused loggers in Dashbuilder

Backport

Merge with https://github.com/kiegroup/appformer/pull/1219