### PR TITLE
[JBPM-10028] Use sensible default for fetching rows

### DIFF
--- a/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/DataSetLookup.java
+++ b/kie-soup-dataset/kie-soup-dataset-api/src/main/java/org/dashbuilder/dataset/DataSetLookup.java
@@ -45,7 +45,7 @@ public class DataSetLookup {
     /**
      * The number of rows to get.
      */
-    protected int numberOfRows = -1;
+    protected int numberOfRows = 1000;
 
     /**
      * Flag indicating this lookup request is in test mode


### PR DESCRIPTION
The default is currently -1 which will pull back all rows from the
database. This causes issues when the database is particularly big.
Kie-servers will use 100% CPU after 5 minutes.

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>