### PR TITLE
[7.67.x] RHPAM-4525 lucene version property removed and inherited from parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
           two versions are being updated on the IP BOM.-->
     <version.com.googlecode.jsonsimple>1.1.1</version.com.googlecode.jsonsimple>
     <version.org.elasticsearch>5.6.16</version.org.elasticsearch>
-    <version.org.apache.lucene>6.6.6</version.org.apache.lucene>
     <version.com.github.tdomzal.junit.docker>0.3</version.com.github.tdomzal.junit.docker>
     <version.com.spotify.docker.client>5.0.2</version.com.spotify.docker.client>
   </properties>


### PR DESCRIPTION

Related PRs:

- https://github.com/kiegroup/kie-soup/pull/255
- https://github.com/kiegroup/kie-soup/pull/256
- https://github.com/kiegroup/kie-soup/pull/257

droolsjbpm-build-boostrap related PRs:

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2081
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2082
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2083