### PR TITLE
[7.67.x] BXMSPROD-1845: removed ElasticSearch dependency and kie-soup-dataset-…

### DIFF
--- a/kie-soup-dataset/pom.xml
+++ b/kie-soup-dataset/pom.xml
@@ -40,7 +40,7 @@
     <module>kie-soup-dataset-sql</module>
     <module>kie-soup-dataset-sql-tests</module>
     <module>kie-soup-dataset-csv</module>
-    <module>kie-soup-dataset-elasticsearch</module>
+    <!--module>kie-soup-dataset-elasticsearch</module-->
     <module>kie-soup-dataset-prometheus</module>
     <module>kie-soup-dataset-kafka</module>
   </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <!-- Required since support for ELS 2.x. Keep in sync with kie-parent or remove when those
           two versions are being updated on the IP BOM.-->
     <version.com.googlecode.jsonsimple>1.1.1</version.com.googlecode.jsonsimple>
-    <version.org.elasticsearch>5.6.16</version.org.elasticsearch>
+    <!-- <version.org.elasticsearch>5.6.16</version.org.elasticsearch> -->
     <version.com.github.tdomzal.junit.docker>0.3</version.com.github.tdomzal.junit.docker>
     <version.com.spotify.docker.client>5.0.2</version.com.spotify.docker.client>
   </properties>
@@ -461,7 +461,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- Elastic search and transitive dependencies for it. -->
+      <!-- Elastic search and transitive dependencies for it.
       <dependency>
         <groupId>org.elasticsearch</groupId>
         <artifactId>elasticsearch</artifactId>
@@ -477,7 +477,7 @@
             <groupId>commons-logging</groupId>
           </exclusion>
         </exclusions>
-      </dependency>
+      </dependency> -->
       <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-core</artifactId>


### PR DESCRIPTION
…ES module from build

https://issues.redhat.com/browse/BXMSPROD-1845

Related PRs:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2168
* https://github.com/kiegroup/kie-soup/pull/260
* https://github.com/kiegroup/appformer/pull/1368
* https://github.com/kiegroup/kie-wb-common/pull/3793
* https://github.com/kiegroup/drools-wb/pull/1562
* https://github.com/kiegroup/jbpm-wb/pull/1579
* https://github.com/kiegroup/optaplanner-wb/pull/421
* https://github.com/kiegroup/kie-wb-distributions/pull/1209