### PR TITLE
Change xstream dependency scope from provided to compile

### DIFF
--- a/kie-soup-xstream/pom.xml
+++ b/kie-soup-xstream/pom.xml
@@ -44,7 +44,6 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
There is a CVE reported from xstream-1.4.19 library. However we don't use that version of xstream. The only possible way I found could be getting the wrong xstream version from kie-soup-xstream library, because it is scoped as provided in the pom.xml. 